### PR TITLE
update keys to work with ethos-systemd

### DIFF
--- a/jobs/clone-database/config.xml
+++ b/jobs/clone-database/config.xml
@@ -29,16 +29,9 @@
   <builders>
     <hudson.tasks.Shell>
       <command>#!bash -x
-PASS_KEY=&quot;/FD/FD_DB_PASSWORD&quot;
-USER_KEY=&quot;/FD/FD_DB_USERNAME&quot;
-PATH_KEY=&quot;/FD/FD_DB_PATH&quot;
-# v3 vs v2 compat.
-eval &apos;$SSHCMD systemctl cat bootstrap|grep v3&apos;
-if [ &quot;$?&quot; == &quot;0&quot; ]; then
-    PASS_KEY=&quot;/environment/RDSPASSWORD&quot;
-    USER_KEY=&quot;/flight-director/config/db-username&quot;
-    PATH_KEY=&quot;/flight-director/config/db-path&quot;
-fi
+PASS_KEY=&quot;/environment/RDSPASSWORD&quot;
+USER_KEY=&quot;/flight-director/config/db-username&quot;
+PATH_KEY=&quot;/flight-director/config/db-path&quot;
 
 # in URL:PORT format
 DB_URL=$(eval &apos;$SSHCMD etcdctl get $PATH_KEY&apos;)

--- a/jobs/clone-database/config.xml
+++ b/jobs/clone-database/config.xml
@@ -29,9 +29,23 @@
   <builders>
     <hudson.tasks.Shell>
       <command>#!bash -x
-PASS_KEY=&quot;/environment/RDSPASSWORD&quot;
-USER_KEY=&quot;/flight-director/config/db-username&quot;
-PATH_KEY=&quot;/flight-director/config/db-path&quot;
+PASS_KEY=&quot;/FD/FD_DB_PASSWORD&quot;
+USER_KEY=&quot;/FD/FD_DB_USERNAME&quot;
+PATH_KEY=&quot;/FD/FD_DB_PATH&quot;
+# v3 vs v2 compat.
+eval &apos;$SSHCMD systemctl cat bootstrap|grep v3&apos;
+if [ &quot;$?&quot; == &quot;0&quot; ]; then
+    PASS_KEY=&quot;/environment/RDSPASSWORD&quot;
+    USER_KEY=&quot;/flight-director/config/db-username&quot;
+    PATH_KEY=&quot;/flight-director/config/db-path&quot;
+fi
+# mesos-systemd vs ethos-systemd compat.
+eval &apos;$SSHCMD systemctl cat bootstrap|grep ethos-systemd&apos;
+if [ &quot;$?&quot; == &quot;0&quot; ]; then
+    PASS_KEY=&quot;/environment/RDSPASSWORD&quot;
+    USER_KEY=&quot;/flight-director/config/db-username&quot;
+    PATH_KEY=&quot;/flight-director/config/db-path&quot;
+fi
 
 # in URL:PORT format
 DB_URL=$(eval &apos;$SSHCMD etcdctl get $PATH_KEY&apos;)


### PR DESCRIPTION
the job was searching for v3 but since ethos-systemd doesn't have v3, it was trying for keys in the old format

@chr0n1x can you take a look? it's a really minor fix to the job. it doesn't work as it is with ethos-systemd
